### PR TITLE
Return false if no canvas was created (eg: jest env)

### DIFF
--- a/src/is-emoji-supported.ts
+++ b/src/is-emoji-supported.ts
@@ -48,6 +48,12 @@ const isSupported = (() => {
   }
 
   const ctx = document.createElement('canvas').getContext('2d');
+
+  // In jest env, ctx is null
+  if (!ctx) {
+    return () => false;
+  }
+
   const CANVAS_HEIGHT = 25;
   const CANVAS_WIDTH = 20;
   const textSize = Math.floor(CANVAS_HEIGHT / 2);


### PR DESCRIPTION
In our project jest tests, `is-emoji-supported` fails because canvas context does not exist.
![image](https://user-images.githubusercontent.com/24303773/85558537-1d514080-b629-11ea-8e53-18be1e88e011.png)
