### PR TITLE
Fix wrong check of canvas validity

### DIFF
--- a/src/is-emoji-supported.ts
+++ b/src/is-emoji-supported.ts
@@ -50,7 +50,7 @@ const isSupported = (() => {
   const canvas = document.createElement('canvas');
 
   // In jest env, canvas has no getContext method
-  if (!canvas || !Object.prototype.hasOwnProperty('getContext')) {
+  if (!canvas || typeof canvas.getContext !== 'function') {
     return () => false;
   }
 


### PR DESCRIPTION
Unable to test on linux mint as all emojis seems to be not supported (But the main function is called as expected)