### PR TITLE
Update github action virtual runner

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Update action runner to macos-latest

Solution found from this documentation : https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners